### PR TITLE
Support out outbound link tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ export default Home() {
 
 #### `PlausibleProvider` props:
 
-| Name           | Description                                                                                                                                                        |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `domain`       | The domain of the site you want to monitor.                                                                                                                        |
-| `customDomain` | Set this if you use a custom domain to serve the analytics script. Defaults to https://plausible.io. See https://plausible.io/docs/custom-domain for more details. |
-| `exclude`      | Set this if you want to exclude a set of pages from being tracked. See https://plausible.io/docs/excluding-pages for more details.                                 |
-| `selfHosted`   | Set this to `true` if you are self hosting your Plausible instance. Otherwise you will get a 404 when requesting the script.                                       |
-| `enabled`      | Use this to explicitly decide whether or not to render script. If not passed the script will be rendered when `process.env.NODE_ENV === 'production'`.             |
-| `integrity`    | Optionally define the [subresource integrity](https://infosec.mozilla.org/guidelines/web_security#subresource-integrity) attribute for extra security.             |
+| Name                 | Description                                                                                                                                                                         |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `domain`             | The domain of the site you want to monitor.                                                                                                                                         |
+| `customDomain`       | Set this if you use a custom domain to serve the analytics script. Defaults to https://plausible.io. See https://plausible.io/docs/custom-domain for more details.                  |
+| `trackOutboundLinks` | Set this to `true` if you want to enable [outbound link click tracking](https://plausible.io/docs/outbound-link-click-tracking#see-all-the-outbound-link-clicks-in-your-dashboard). |
+| `exclude`            | Set this if you want to exclude a set of pages from being tracked. See https://plausible.io/docs/excluding-pages for more details.                                                  |
+| `selfHosted`         | Set this to `true` if you are self hosting your Plausible instance. Otherwise you will get a 404 when requesting the script.                                                        |
+| `enabled`            | Use this to explicitly decide whether or not to render script. If not passed the script will be rendered when `process.env.NODE_ENV === 'production'`.                              |
+| `integrity`          | Optionally define the [subresource integrity](https://infosec.mozilla.org/guidelines/web_security#subresource-integrity) attribute for extra security.                              |
 
 ### Send custom events:
 

--- a/index.tsx
+++ b/index.tsx
@@ -5,6 +5,7 @@ export default function PlausibleProvider(props: {
   domain: string
   customDomain?: string
   children: ReactNode | ReactNode[]
+  trackOutboundLinks?: boolean
   exclude?: string
   selfHosted?: boolean
   enabled?: boolean
@@ -27,7 +28,9 @@ export default function PlausibleProvider(props: {
               props.selfHosted || customDomain === 'https://plausible.io'
                 ? 'plausible'
                 : 'index'
-            }${props.exclude ? '.exclusions' : ''}.js`}
+            }${props.trackOutboundLinks ? '.outbound-links' : ''}${
+              props.exclude ? '.exclusions' : ''
+            }.js`}
             integrity={props.integrity}
             crossOrigin={props.integrity ? 'anonymous' : undefined}
           />

--- a/test/pages/trackOutboundLinks.js
+++ b/test/pages/trackOutboundLinks.js
@@ -1,0 +1,5 @@
+import PlausibleProvider from '../../dist'
+
+export default function Home() {
+  return <PlausibleProvider domain="example.com" trackOutboundLinks />
+}

--- a/test/pages/trackOutboundLinksExclude.js
+++ b/test/pages/trackOutboundLinksExclude.js
@@ -1,0 +1,7 @@
+import PlausibleProvider from '../../dist'
+
+export default function Home() {
+  return (
+    <PlausibleProvider domain="example.com" trackOutboundLinks exclude="page" />
+  )
+}

--- a/test/test.js
+++ b/test/test.js
@@ -71,6 +71,40 @@ describe('PlausibleProvider', () => {
     })
   })
 
+  describe('when tracking outbound links like <PlausibleProvider domain="example.com" trackOutboundLinks />', () => {
+    const $ = cheerio.load(
+      fs.readFileSync('./out/trackOutboundLinks.html', 'utf8')
+    )
+    const script = $('head > script[data-domain="example.com"]')
+
+    describe('the script', () => {
+      test('points to https://plausible.io/js/plausible.outbound-links.js', () => {
+        expect(script.attr('src')).toBe(
+          'https://plausible.io/js/plausible.outbound-links.js'
+        )
+      })
+    })
+  })
+
+  describe('when tracking outbound links and excluding a page like <PlausibleProvider domain="example.com" trackOutboundLinks exclude="page" />', () => {
+    const $ = cheerio.load(
+      fs.readFileSync('./out/trackOutboundLinksExclude.html', 'utf8')
+    )
+    const script = $('head > script[data-domain="example.com"]')
+
+    describe('the script', () => {
+      test('has the data-exclude attribute', () => {
+        expect(script.data('exclude')).toBe('page')
+      })
+
+      test('points to https://plausible.io/js/plausible.outbound-links.exclusions.js', () => {
+        expect(script.attr('src')).toBe(
+          'https://plausible.io/js/plausible.outbound-links.exclusions.js'
+        )
+      })
+    })
+  })
+
   describe('when using a self hosted instance like <PlausibleProvider domain="example.com" customDomain="https://custom.example.com" selfHosted>', () => {
     const $ = cheerio.load(fs.readFileSync('./out/selfHosted.html', 'utf8'))
     const script = $('head > script[data-domain="example.com"]')


### PR DESCRIPTION
This adds support for [Outbound Link Click Tracking](https://plausible.io/docs/outbound-link-click-tracking). Tests and documentation have been updated. Closes #8 https://github.com/4lejandrito/next-plausible/issues/8.