### PR TITLE
Ignore locale on all redirects

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -58,22 +58,27 @@ export function withPlausibleProxy(options: NextPlausibleProxyOptions = {}) {
         {
           source: getScriptPath(options),
           destination: getRemoteScript(),
+          locale: false,
         },
         {
           source: getScriptPath(options, 'exclusions'),
           destination: getRemoteScript('exclusions'),
+          locale: false,
         },
         {
           source: getScriptPath(options, 'outbound-links'),
           destination: getRemoteScript('outbound-links'),
+          locale: false,
         },
         {
           source: getScriptPath(options, 'outbound-links', 'exclusions'),
           destination: getRemoteScript('outbound-links', 'exclusions'),
+          locale: false,
         },
         {
           source: getApiEndpoint(options),
           destination: `${domain}/api/event`,
+          locale: false,
         },
       ]
       const rewrites = await nextConfig.rewrites?.()


### PR DESCRIPTION
We lost tracking when adding a locale config in next.config.js due to next.js `rewrites` matching locale by default

Worked around it in an open source repo here: https://github.com/TheoBr/init.tips/pull/2

I don't see any reason why these sources should ever be locale-specific, so I think ignoring locale always is the safest bet :)