### PR TITLE
Don't pass locale on to plausible.io

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head'
 import { NextConfig } from 'next'
 import getConfig from 'next/config'
 import getCombinations from './lib/combinations'
+import { Rewrite } from 'next/dist/lib/load-custom-routes'
 
 type NextPlausibleProxyOptions = {
   subdirectory?: string
@@ -61,10 +62,11 @@ export function withPlausibleProxy(options: NextPlausibleProxyOptions = {}) {
           },
           ...modifiers
         )
-      const plausibleRewrites = [
+      const plausibleRewrites: Rewrite[] = [
         {
           source: getScriptPath(options),
           destination: getRemoteScript(),
+          locale: false,
         },
         ...getCombinations(allModifiers).map((modifiers) => ({
           source: getScriptPath(options, ...modifiers),
@@ -73,6 +75,7 @@ export function withPlausibleProxy(options: NextPlausibleProxyOptions = {}) {
         {
           source: getApiEndpoint(options),
           destination: `${domain}/api/event`,
+          locale: false,
         },
       ]
       const rewrites = await nextConfig.rewrites?.()


### PR DESCRIPTION
Hi, we just faced an issue and believe that this fix might be helpful.

Initial Setup:

- We use plausible.io and next.js and deploy to vercel.com
- We use `withPlausibleProxy` to proxy the event API "/api/event"

Change: 

- We enabled [i18n routing](https://nextjs.org/docs/advanced-features/i18n-routing)

Issue:

- Since a couple of hours (around 10h) we get no analytics data from the website
- The developer console shows an HTTP 404 response from "/api/event"
- There has been no recent update to next.js or next-plausible. But a recent change enabled the i18n routing.

Possible fixes:

- Option 1: Removing `withPlausibleProxy` changes the call from  "/api/event" to  "plausible.io/api/event" which then returns an HTTP 200 and data arrives at the plausible dashboard
- Option 2: We added custom rewrites and set `locale: false` as described in [next rewrites](https://nextjs.org/docs/api-reference/next.config.js/rewrites)

``` 
async rewrites() {
            return [
                {
                    source: '/js/script.js',
                    destination: 'https://plausible.io/js/plausible.js',
                    locale: false,
                },
                {
                    source: '/api/event',
                    destination: 'https://plausible.io/api/event',
                    locale: false,
                },
            ]
        },
```

This PR would apply the second option to next-plausible. If the change is okay, then I still might need some support in adding a test for this issue.

