### PR TITLE
Remove `async` attribute

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -120,7 +120,6 @@ export default function PlausibleProvider(props: {
       <Head>
         {enabled && (
           <script
-            async
             defer
             data-api={proxyOptions ? getApiEndpoint(proxyOptions) : undefined}
             data-domain={props.domain}

--- a/test/page/test.js
+++ b/test/page/test.js
@@ -11,8 +11,7 @@ describe('PlausibleProvider', () => {
     })
 
     describe('the script', () => {
-      test('loads asynchronously', () => {
-        expect(script.attr('async')).toBeDefined()
+      test('is deferred', () => {
         expect(script.attr('defer')).toBeDefined()
       })
 

--- a/test/proxy/test.ts
+++ b/test/proxy/test.ts
@@ -40,8 +40,7 @@ describe('PlausibleProvider', () => {
     })
 
     describe('the script', () => {
-      test('loads asynchronously', () => {
-        expect(script.attr('async')).toBeDefined()
+      test('is deferred', () => {
         expect(script.attr('defer')).toBeDefined()
       })
 
@@ -171,6 +170,7 @@ describe('PlausibleProvider', () => {
           }
         })
         await page.goto(`${url}/notFound`)
+        await page.waitForFunction('!!window.plausible')
         expect(plausibleEvents).toBe(2)
       } finally {
         await browser.close()

--- a/test/proxyLocale/test.ts
+++ b/test/proxyLocale/test.ts
@@ -18,8 +18,7 @@ describe('PlausibleProvider', () => {
     })
 
     describe('the script', () => {
-      test('loads asynchronously', () => {
-        expect(script.attr('async')).toBeDefined()
+      test('is deferred', () => {
         expect(script.attr('defer')).toBeDefined()
       })
 


### PR DESCRIPTION
The `async` and `defer` attributes should not be used together when loading a script. Since `async` [has a higher priority](https://stackoverflow.com/a/55389033/9046809), `defer` will be ignored.

I advise to remove `async` to make proper use of `defer`, which will not block the render process at all, as shown in [this](https://stackoverflow.com/a/39711009/9046809) thread.

![image](https://user-images.githubusercontent.com/32395585/160358871-ca050de5-fdd0-46b0-847e-30279c0079cc.png)
