### PR TITLE
Add check in case afterFiles is not defined

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -139,8 +139,11 @@ export function withPlausibleProxy(options: NextPlausibleProxyOptions = {}) {
           return plausibleRewrites
         } else if (Array.isArray(rewrites)) {
           return rewrites.concat(plausibleRewrites)
-        } else {
+        } else if (rewrites.afterFiles) {
           rewrites.afterFiles = rewrites.afterFiles.concat(plausibleRewrites)
+          return rewrites
+        } else {
+          rewrites.afterFiles = plausibleRewrites
           return rewrites
         }
       },


### PR DESCRIPTION
I got an error when using the `withPlausibleProxy` wrapper when I had following code:

![image](https://user-images.githubusercontent.com/19892721/217159227-31005b45-df0a-4635-8fc0-c4296ba2df87.png)

Uncommenting the afterFiles line fixes the error, but adding this check in the wrapper code will prevent the next-plausible from erroring in the first place. Otherwise, the error is a little confusing:

![image](https://user-images.githubusercontent.com/19892721/217159542-a91eb951-5654-4bb1-80bf-2432512fac03.png)
