### PR TITLE
Add custom properties for pageviews support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ export default function RootLayout({ children }) {
 #### `PlausibleProvider` Props
 
 | Name                 | Description                                                                                                                                                                         |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `domain`             | The domain of the site you want to monitor.                                                                                                                                         |
 | `customDomain`       | Set this if you use a custom domain to serve the analytics script. Defaults to https://plausible.io. See https://plausible.io/docs/custom-domain for more details.                  |
 | `trackOutboundLinks` | Set this to `true` if you want to enable [outbound link click tracking](https://plausible.io/docs/outbound-link-click-tracking#see-all-the-outbound-link-clicks-in-your-dashboard). |
@@ -70,6 +70,7 @@ export default function RootLayout({ children }) {
 | `taggedEvents`       | Set this to `true` if you want to enable [custom event tracking in HTML elements](https://plausible.io/docs/custom-event-goals).                                                    |
 | `trackLocalhost`     | Set this to `true` if you want to enable localhost tracking as described [here](https://plausible.io/docs/script-extensions).                                                       |
 | `manualPageviews`    | Set this to `true` if you want to disable automatic pageview events as described [here](https://plausible.io/docs/script-extensions#plausiblemanualjs).                             |
+| `pageviewProps`      | Set this to `true` if you want to enable custom properties for pageviews as described [here](https://plausible.io/docs/custom-pageview-props).                                      |
 | `exclude`            | Set this if you want to exclude a set of pages from being tracked. See https://plausible.io/docs/excluding-pages for more details.                                                  |
 | `selfHosted`         | Set this to `true` if you are self hosting your Plausible instance. Otherwise you will get a 404 when requesting the script.                                                        |
 | `enabled`            | Use this to explicitly decide whether or not to render script. If not passed the script will be rendered in production environments.                                                |

--- a/index.tsx
+++ b/index.tsx
@@ -29,6 +29,7 @@ const allModifiers = [
   'outbound-links',
   'file-downloads',
   'tagged-events',
+  'pageview-props',
 ] as const
 type ScriptModifier = typeof allModifiers[number]
 
@@ -167,6 +168,10 @@ export default function PlausibleProvider(props: {
    */
   manualPageviews?: boolean
   /**
+   * Set this to true if you want to enable custom properties for pageviews as described https://plausible.io/docs/custom-pageview-props.
+   */
+  pageviewProps?: boolean
+  /**
    * Set this to true if you want to enable localhost tracking as described https://plausible.io/docs/script-extensions.
    */
   trackLocalhost?: boolean
@@ -234,6 +239,7 @@ export default function PlausibleProvider(props: {
               },
               props.trackLocalhost ? 'local' : null,
               props.manualPageviews ? 'manual' : null,
+              props.pageviewProps ? 'pageview-props' : null,
               props.trackOutboundLinks ? 'outbound-links' : null,
               props.exclude ? 'exclusions' : null,
               props.trackFileDownloads ? 'file-downloads' : null,


### PR DESCRIPTION
Hello! I love the package. We are using [Custom properties for pageviews
](https://plausible.io/docs/custom-pageview-props) and I spotted a lack of support for this. This PRs adds it. Custom properties can be then passed using the `scriptProps`:
```js
<PlausibleProvider
  ...
  scriptProps={{
    'event-author': 'John Doe',
  }}
>
```