### PR TITLE
docs: explain when it has to be explicitly enabled in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ export default function RootLayout({ children }) {
 | `hash`               | Set this to `true` if you want to [use hash-based routing](https://plausible.io/docs/hash-based-routing).                                                                                                |
 | `exclude`            | Set this if you want to exclude a set of pages from being tracked. See https://plausible.io/docs/excluding-pages for more details.                                                                       |
 | `selfHosted`         | Set this to `true` if you are self hosting your Plausible instance. Otherwise you will get a 404 when requesting the script.                                                                             |
-| `enabled`            | Use this to explicitly decide whether or not to render script. If not passed the script will be rendered in production environments.                                                                     |
+| `enabled`            | Use this to explicitly decide whether or not to render script. If not passed the script will be rendered in production environments (checking NODE_ENV and VERCEL_ENV).                                                                     |
 | `integrity`          | Optionally define the [subresource integrity](https://infosec.mozilla.org/guidelines/web_security#subresource-integrity) attribute for extra security.                                                   |
 | `scriptProps`        | Optionally override any of the props passed to the script element. See [example](test/page/pages/scriptProps.js).                                                                                        |
 

--- a/lib/PlausibleProvider.tsx
+++ b/lib/PlausibleProvider.tsx
@@ -64,7 +64,7 @@ export default function PlausibleProvider(props: {
    */
   selfHosted?: boolean
   /**
-   * Use this to explicitly decide whether or not to render script. If not passed the script will be rendered in production environments.
+   * Use this to explicitly decide whether or not to render script. If not passed the script will be rendered in production environments (checking NODE_ENV and VERCEL_ENV).
    */
   enabled?: boolean
   /**


### PR DESCRIPTION
I found it a tad confusing.