### PR TITLE
PoC: plausible client for server side

### DIFF
--- a/lib/PlausibleNode.tsx
+++ b/lib/PlausibleNode.tsx
@@ -1,0 +1,30 @@
+import { headers } from "next/headers";
+
+type EventOptions = {
+  domain?: string;
+  url?: string;
+}
+export class Plausible {
+  baseApiUrl: string;
+
+  constructor(baseApiUrl: string) {
+    this.baseApiUrl = baseApiUrl || "https://plausible.io";
+  }
+
+  async event(name: string, options: EventOptions = {}) {
+    const head = headers()
+    await fetch(`${this.baseApiUrl}/api/event`, {
+      method: "POST",
+      headers: {
+        "User-Agent": head.get("user-agent"),
+        "X-Forwarded-For": head.get("x-forwarded-for"),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name,
+        domain: options.domain || head.get("host"),
+        url: options.url || head.get("referer"),
+      }),
+    })
+  }
+}


### PR DESCRIPTION
This is a quick PoC for supporting the plausible API on the server side for nextJS

The main inspiration came from the PostHog-node library which does something similar.

### Structure
- Setup as a class to create a persistent client. This would be helpful for inserting context into api route handlers (ie: tRPC)
- Constructor accepts the `baseApiUrl`. This is for the self-hosted use case
- event accepts 2 parameters: name, options
  - name => name of the custom event
  - options => these support passing in a custom domain and url

Admittedly, this structure supports my personal use-case, but it should be translatable to other's use cases fairly well