### PR TITLE
Ensure PlausibleProvider remounts <Script> when props change

### DIFF
--- a/lib/PlausibleProvider.tsx
+++ b/lib/PlausibleProvider.tsx
@@ -5,6 +5,7 @@ import {
   getApiEndpoint,
   getScriptPath,
   getRemoteScriptName,
+  hashObject,
   NextPlausiblePublicProxyOptions,
 } from './common'
 
@@ -96,10 +97,14 @@ export default function PlausibleProvider(props: {
       }
     : undefined
 
+  // generate hash of props so that <Script> remounts when they change
+  const propsHash = hashObject(props)
+
   return (
     <>
       {enabled && (
         <Script
+          key={'plausible-' + propsHash}
           async
           defer
           data-api={proxyOptions ? getApiEndpoint(proxyOptions) : undefined}
@@ -140,6 +145,7 @@ export default function PlausibleProvider(props: {
       )}
       {enabled && (
         <Script
+          key={'plausible-init-' + propsHash}
           id="next-plausible-init"
           dangerouslySetInnerHTML={{
             __html: `window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }`,

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -1,3 +1,5 @@
+import crypto from 'crypto'
+
 export type NextPlausibleProxyOptions = {
   subdirectory?: string
   scriptName?: string
@@ -49,3 +51,9 @@ export const getApiEndpoint = (options: NextPlausiblePublicProxyOptions) =>
   `${options.basePath ?? ''}/${options.subdirectory ?? 'proxy'}/api/event${
     options.trailingSlash ? '/' : ''
   }`
+
+export const hashObject = (obj: any) =>
+  crypto
+    .createHash('md5')
+    .update(JSON.stringify(obj || {}))
+    .digest('hex')


### PR DESCRIPTION
**Description:**
This PR fixes the issue where changes to `pageviewProps` or other props in `<PlausibleProvider />` were not reflected in Plausible analytics.

### Problem

The `<Script>` tags created by `next-plausible` only render once. When props such as `pageviewProps` change (e.g., `language: locale`), React does not remount the `<Script>` element, so analytics continue sending stale values.

### Solution

* Introduced a new utility `hashObject` in `common.ts` that generates an MD5 hash of the full props object.
* Applied this hash as part of the `key` for both `<Script>` tags inside `PlausibleProvider`.
* This ensures React remounts the scripts whenever props change, applying the latest values.

### Implementation details

* Added `hashObject` using Node’s `crypto` module.
* Used `key={'plausible-' + propsHash}` and `key={'plausible-init-' + propsHash}` on the script tags.
* No breaking changes to the public API.

### Example

Before:

```jsx
<PlausibleProvider pageviewProps={{ language: locale }}>
  {children}
</PlausibleProvider>

// Changing locale did not update analytics.
```

After:

```jsx
<PlausibleProvider pageviewProps={{ language: locale }}>
  {children}
</PlausibleProvider>

// Changing locale now updates analytics with the new language.
```

### References

Fixes [#146](https://github.com/4lejandrito/next-plausible/issues/146)